### PR TITLE
Fixed, EditText format error

### DIFF
--- a/intlphoneinput/src/main/java/net/rimoto/intlphoneinput/IntlPhoneInput.java
+++ b/intlphoneinput/src/main/java/net/rimoto/intlphoneinput/IntlPhoneInput.java
@@ -191,7 +191,12 @@ public class IntlPhoneInput extends RelativeLayout {
         @Override
         public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
             mSelectedCountry = mCountrySpinnerAdapter.getItem(position);
+
+            //Make sure that the watcher is added into the listeners of the edittext
+            //after updating the country selected...
+            mPhoneEdit.removeTextChangedListener(mPhoneNumberWatcher);
             mPhoneNumberWatcher = new PhoneNumberWatcher(mSelectedCountry.getIso());
+            mPhoneEdit.addTextChangedListener(mPhoneNumberWatcher);
 
             setHint();
         }


### PR DESCRIPTION
Make sure that not only the class reference for the text watcher is updated, but also the listener, without these changes, basically we are never really changing the listener internally and we are always left with the default one....